### PR TITLE
Add /challah redirect with bread emoji easter egg

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,15 @@
 const nextConfig = {
   reactStrictMode: true,
   trailingSlash: true,
+  async redirects() {
+    return [
+      {
+        source: '/challah',
+        destination: 'https://cauldron-f900a.web.app/u/nadav/D93FCA73-EAFC-42D0-AA63-460A88D00515',
+        permanent: false,
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;

--- a/pages/cauldron.jsx
+++ b/pages/cauldron.jsx
@@ -1,7 +1,22 @@
 import Head from 'next/head';
 import Link from 'next/link';
+import { useState, useCallback } from 'react';
 
 export default function CauldronPage() {
+  const [confetti, setConfetti] = useState([]);
+
+  const triggerConfetti = useCallback(() => {
+    const particles = Array.from({ length: 12 }, (_, i) => ({
+      id: Date.now() + i,
+      emoji: ['🥖', '🍞', '🥐', '🥯', '✨'][Math.floor(Math.random() * 5)],
+      x: (Math.random() - 0.5) * 120,
+      y: (Math.random() - 0.5) * 120 - 30,
+      rotation: Math.random() * 360,
+    }));
+    setConfetti(particles);
+    setTimeout(() => setConfetti([]), 800);
+  }, []);
+
   return (
     <>
       <Head>
@@ -32,14 +47,32 @@ export default function CauldronPage() {
           next favorite dish.
         </p>
 
-        <a
-          href="https://apps.apple.com/us/app/cauldron-magical-recipes/id6754004943"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="download-link"
-        >
-          Download
-        </a>
+        <div className="download-row">
+          <a
+            href="https://apps.apple.com/us/app/cauldron-magical-recipes/id6754004943"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="download-link"
+          >
+            Download
+          </a>
+          <span className="easter-egg-wrapper">
+            <Link href="/challah" className="easter-egg" onMouseEnter={triggerConfetti}>🍞</Link>
+            {confetti.map((p) => (
+              <span
+                key={p.id}
+                className="confetti-particle"
+                style={{
+                  '--x': `${p.x}px`,
+                  '--y': `${p.y}px`,
+                  '--r': `${p.rotation}deg`,
+                }}
+              >
+                {p.emoji}
+              </span>
+            ))}
+          </span>
+        </div>
 
         <div className="screenshots">
           <img src="/assets/cauldron/cook_tab.PNG" alt="Cook Tab" />

--- a/src/index.css
+++ b/src/index.css
@@ -329,6 +329,54 @@ footer {
   color: var(--text-muted);
 }
 
+.easter-egg-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.easter-egg {
+  opacity: 0.6;
+  display: inline-block;
+  transition: opacity 0.2s ease, transform 0.3s ease;
+  cursor: pointer;
+  font-size: 18px;
+}
+
+.easter-egg:hover {
+  opacity: 1;
+  animation: spin 0.5s ease-in-out;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg) scale(1); }
+  50% { transform: rotate(180deg) scale(1.3); }
+  100% { transform: rotate(360deg) scale(1); }
+}
+
+.confetti-particle {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  font-size: 14px;
+  pointer-events: none;
+  animation: confetti-burst 0.7s ease-out forwards;
+}
+
+@keyframes confetti-burst {
+  0% {
+    transform: translate(-50%, -50%) translate(0, 0) rotate(0deg) scale(0);
+    opacity: 1;
+  }
+  20% {
+    transform: translate(-50%, -50%) translate(calc(var(--x) * 0.3), calc(var(--y) * 0.3)) rotate(calc(var(--r) * 0.3)) scale(1);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-50%, -50%) translate(var(--x), var(--y)) rotate(var(--r)) scale(0.5);
+    opacity: 0;
+  }
+}
+
 /* Focus states */
 a:focus-visible,
 button:focus-visible {
@@ -410,12 +458,18 @@ button:focus-visible {
   --accent-hover: #e68400;
 }
 
+.download-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 32px;
+}
+
 .testflight-link,
 .download-link {
   display: inline-block;
   font-size: 15px;
   color: var(--accent);
-  margin-bottom: 32px;
   transition: color 0.15s ease;
 }
 


### PR DESCRIPTION
- Add redirect from /challah to Cauldron recipe URL
- Add bread emoji easter egg next to Download button on Cauldron page
- Emoji spins and triggers bread-themed confetti on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)