### PR TITLE
Use dvh units for better mobile viewport handling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -40,7 +40,7 @@ body {
   color: var(--text);
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
-  min-height: 100vh;
+  min-height: 100dvh;
 }
 
 ::selection {
@@ -62,7 +62,7 @@ a {
 
 /* Minimal Layout */
 .minimal-page {
-  min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
Replaces 100vh with 100dvh to fix content being cut off on mobile when browser chrome (address bar) is visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)